### PR TITLE
Add pointer to accompanying blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## AppStream QGIS Blog Post Supporting Content
 
-This project contains source code to support an AWS blog post showing how to use Amazon AppStream 2.0 to stream the QGIS application.
+This project contains source code to support an [AWS blog post](https://aws.amazon.com/blogs/publicsector/how-to-deliver-performant-gis-desktop-applications-amazon-appstream-2-0/) showing how to use Amazon AppStream 2.0 to stream the QGIS application.  The accompanying blog post should be used as the primary guide for deploying code within this repository.  The accompanying blog details important prerequisite information before the CloudFormation template in this repository can be deployed successfully.
 
 ## Security
 


### PR DESCRIPTION
Adding link to accompanying blog post and highlighting the importance of using the blog post as the primary guide for deployment of this solution.

*Issue #, if available:*
https://github.com/aws-samples/appstream-qgis-blog/issues/1

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
